### PR TITLE
Search Service

### DIFF
--- a/src/services/SearchService/JsonSearchServiceAdapter.spec.ts
+++ b/src/services/SearchService/JsonSearchServiceAdapter.spec.ts
@@ -1,0 +1,80 @@
+import JsonSearchServiceAdapter from "./JsonSearchServiceAdapter";
+
+let jsonSearchServiceAdapter: JsonSearchServiceAdapter;
+
+beforeEach(() => {
+  jsonSearchServiceAdapter = new JsonSearchServiceAdapter();
+});
+
+it("should return search result for article 282", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("282");
+  expect(results).toEqual([
+    {
+      text: {
+        ru:
+          "Возбуждение ненависти либо вражды, а равно унижение человеческого достоинства",
+      },
+      id: "282",
+    },
+  ]);
+});
+
+it("should return search result for article 281", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("281");
+  expect(results).toEqual([
+    {
+      text: {
+        ru: "Диверсия",
+      },
+      id: "281",
+    },
+  ]);
+});
+
+it("should return search result for query '281 '", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("281 ");
+  expect(results).toEqual([
+    {
+      text: {
+        ru: "Диверсия",
+      },
+      id: "281",
+    },
+  ]);
+});
+
+it("should return search result for query 'Диверсия'", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("Диверсия");
+  expect(results).toEqual([
+    {
+      text: {
+        ru: "Диверсия",
+      },
+      id: "281",
+    },
+  ]);
+});
+
+it("should return search result for query 'диверсия'", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("диверсия");
+  expect(results).toEqual([
+    {
+      text: {
+        ru: "Диверсия",
+      },
+      id: "281",
+    },
+  ]);
+});
+
+it("should return search result for query 'диверсия '", async () => {
+  const results = await jsonSearchServiceAdapter.getArticlesByText("диверсия ");
+  expect(results).toEqual([
+    {
+      text: {
+        ru: "Диверсия",
+      },
+      id: "281",
+    },
+  ]);
+});

--- a/src/services/SearchService/JsonSearchServiceAdapter.ts
+++ b/src/services/SearchService/JsonSearchServiceAdapter.ts
@@ -1,0 +1,37 @@
+import ukRf from "content/ук-рф.json";
+import type {
+  SearchResult,
+  SearchServiceAdapter,
+} from "./SearchServiceAdapter";
+
+type Clause = typeof ukRf[number]["children"][number]["children"][number];
+
+class JsonSearchAdapter implements SearchServiceAdapter {
+  async getArticlesByText(query: string): Promise<SearchResult[]> {
+    const results: SearchResult[] = [];
+    for (const part of ukRf) {
+      for (const section of part.children) {
+        for (const clause of section.children) {
+          if (clause.id.toString() === query.trim()) {
+            results.push(this.transformResult(clause));
+            continue;
+          }
+          if (clause.text.ru.toLowerCase() === query.toLowerCase().trim()) {
+            results.push(this.transformResult(clause));
+            continue;
+          }
+        }
+      }
+    }
+    return results;
+  }
+
+  private transformResult(clause: Clause): SearchResult {
+    return {
+      text: clause.text,
+      id: clause.id.toString(),
+    };
+  }
+}
+
+export default JsonSearchAdapter;

--- a/src/services/SearchService/SearchService.spec.ts
+++ b/src/services/SearchService/SearchService.spec.ts
@@ -1,0 +1,71 @@
+import SearchService from "./SearchService";
+import { SearchResult, SearchServiceAdapter } from "./SearchServiceAdapter";
+
+let searchService: SearchService;
+
+const searchServiceMock: SearchServiceAdapter = {
+  getArticlesByText: jest.fn(),
+};
+
+beforeEach(() => {
+  searchService = new SearchService(searchServiceMock);
+});
+
+const fakeSearchResult282: SearchResult[] = [
+  {
+    text: {
+      ru: "Foo",
+    },
+    id: "282",
+  },
+];
+
+const fakeSearchResult281: SearchResult[] = [
+  {
+    text: {
+      ru: "Bar",
+    },
+    id: "281",
+  },
+];
+
+const mockGetArticlesByTextResponse = (response: SearchResult[]) => {
+  (searchServiceMock.getArticlesByText as jest.Mock).mockImplementationOnce(
+    () => {
+      return response;
+    }
+  );
+};
+
+it("should return autocomplete results for '282'", async () => {
+  mockGetArticlesByTextResponse(fakeSearchResult282);
+  const results = await searchService.getAutocompleteItems("282", 2019, "ru");
+  expect(results).toEqual([
+    {
+      text: "Статья 282. Foo",
+      link: "/282/2019/",
+    },
+  ]);
+});
+
+it("should return autocomplete results for '282' for different year", async () => {
+  mockGetArticlesByTextResponse(fakeSearchResult282);
+  const results = await searchService.getAutocompleteItems("282", 2018, "ru");
+  expect(results).toEqual([
+    {
+      text: "Статья 282. Foo",
+      link: "/282/2018/",
+    },
+  ]);
+});
+
+it("should return autocomplete results for '281'", async () => {
+  mockGetArticlesByTextResponse(fakeSearchResult281);
+  const results = await searchService.getAutocompleteItems("281", 2019, "ru");
+  expect(results).toEqual([
+    {
+      text: "Статья 281. Bar",
+      link: "/281/2019/",
+    },
+  ]);
+});

--- a/src/services/SearchService/SearchService.spec.ts
+++ b/src/services/SearchService/SearchService.spec.ts
@@ -37,35 +37,51 @@ const mockGetArticlesByTextResponse = (response: SearchResult[]) => {
   );
 };
 
-it("should return autocomplete results for '282'", async () => {
-  mockGetArticlesByTextResponse(fakeSearchResult282);
-  const results = await searchService.getAutocompleteItems("282", 2019, "ru");
-  expect(results).toEqual([
-    {
-      text: "Статья 282. Foo",
-      link: "/282/2019/",
-    },
-  ]);
+describe("getAutocompleteItems", () => {
+  it("should return autocomplete results for '282'", async () => {
+    mockGetArticlesByTextResponse(fakeSearchResult282);
+    const results = await searchService.getAutocompleteItems("282", 2019, "ru");
+    expect(results).toEqual([
+      {
+        text: "Статья 282. Foo",
+        link: "/282/2019/",
+      },
+    ]);
+  });
+
+  it("should return autocomplete results for '282' for different year", async () => {
+    mockGetArticlesByTextResponse(fakeSearchResult282);
+    const results = await searchService.getAutocompleteItems("282", 2018, "ru");
+    expect(results).toEqual([
+      {
+        text: "Статья 282. Foo",
+        link: "/282/2018/",
+      },
+    ]);
+  });
+
+  it("should return autocomplete results for '281'", async () => {
+    mockGetArticlesByTextResponse(fakeSearchResult281);
+    const results = await searchService.getAutocompleteItems("281", 2019, "ru");
+    expect(results).toEqual([
+      {
+        text: "Статья 281. Bar",
+        link: "/281/2019/",
+      },
+    ]);
+  });
 });
 
-it("should return autocomplete results for '282' for different year", async () => {
-  mockGetArticlesByTextResponse(fakeSearchResult282);
-  const results = await searchService.getAutocompleteItems("282", 2018, "ru");
-  expect(results).toEqual([
-    {
-      text: "Статья 282. Foo",
-      link: "/282/2018/",
-    },
-  ]);
-});
-
-it("should return autocomplete results for '281'", async () => {
-  mockGetArticlesByTextResponse(fakeSearchResult281);
-  const results = await searchService.getAutocompleteItems("281", 2019, "ru");
-  expect(results).toEqual([
-    {
-      text: "Статья 281. Bar",
-      link: "/281/2019/",
-    },
-  ]);
+describe("getHelpItems", () => {
+  it("should return default help items", () => {
+    const result = searchService.getHelpItems("ru");
+    expect(result).toEqual([
+      "282",
+      "282 часть 2",
+      "против личности",
+      "против государствa",
+      "экстремизм",
+      "убийство",
+    ]);
+  });
 });

--- a/src/services/SearchService/SearchService.ts
+++ b/src/services/SearchService/SearchService.ts
@@ -1,0 +1,32 @@
+import { SearchServiceAdapter } from "./SearchServiceAdapter";
+
+class SearchService {
+  private searchServiceAdaper: SearchServiceAdapter;
+
+  constructor(searchServiceAdaper: SearchServiceAdapter) {
+    this.searchServiceAdaper = searchServiceAdaper;
+  }
+
+  async getAutocompleteItems(
+    queryString: string,
+    year: number,
+    locale: "ru"
+  ): Promise<SearchResult[]> {
+    const results = await this.searchServiceAdaper.getArticlesByText(
+      queryString
+    );
+    return results.map((r) => {
+      return {
+        text: `Статья ${r.id}. ${r.text[locale]}`,
+        link: `/${r.id}/${year}/`,
+      };
+    });
+  }
+}
+
+interface SearchResult {
+  text: string;
+  link: string;
+}
+
+export default SearchService;

--- a/src/services/SearchService/SearchService.ts
+++ b/src/services/SearchService/SearchService.ts
@@ -22,9 +22,21 @@ class SearchService {
       };
     });
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getHelpItems(locale: "ru"): string[] {
+    return [
+      "282",
+      "282 часть 2",
+      "против личности",
+      "против государствa",
+      "экстремизм",
+      "убийство",
+    ];
+  }
 }
 
-interface SearchResult {
+export interface SearchResult {
   text: string;
   link: string;
 }

--- a/src/services/SearchService/SearchServiceAdapter.ts
+++ b/src/services/SearchService/SearchServiceAdapter.ts
@@ -1,0 +1,10 @@
+export interface SearchServiceAdapter {
+  getArticlesByText(query: string): Promise<SearchResult[]>;
+}
+
+export interface SearchResult {
+  text: {
+    ru: string;
+  };
+  id: string;
+}

--- a/src/services/SearchService/index.ts
+++ b/src/services/SearchService/index.ts
@@ -1,0 +1,7 @@
+import JsonSearchServiceAdapter from "./JsonSearchServiceAdapter";
+import SearchService from "./SearchService";
+
+const jsonSearchServiceAdapter = new JsonSearchServiceAdapter();
+const searchService = new SearchService(jsonSearchServiceAdapter);
+
+export default searchService;

--- a/src/services/SearchService/index.ts
+++ b/src/services/SearchService/index.ts
@@ -5,3 +5,4 @@ const jsonSearchServiceAdapter = new JsonSearchServiceAdapter();
 const searchService = new SearchService(jsonSearchServiceAdapter);
 
 export default searchService;
+export type { SearchResult } from "./SearchService";


### PR DESCRIPTION
Уже имплементировано:

- Поиск по номеру статьи (282)
- Поиск по тексту (Диверсия)
- Поиск по тексту вне зависимости от регистра (диверсия)
- Поиск по номеру стать или по тексту с вырезанием пробелов ('282 ')
- Возврат подсказок под поиском

Осталось сделать:

- Поиск по части статьи (прямая ссылка на часть)
- Поиск по главе (+открытие каталога на нужной главе)